### PR TITLE
Add trigger on shell startup

### DIFF
--- a/env.plugin.zsh
+++ b/env.plugin.zsh
@@ -7,4 +7,6 @@ load-local-conf() {
        source .env
      fi
 }
+
+load-local-conf
 add-zsh-hook chpwd load-local-conf


### PR DESCRIPTION
Hey there @johnhamelink ! First of all I'd like to thank you for authoring this plugin, it's been a convenient little time saver for me and surely for many others. :)

Upon experimenting with the plugin in a setup where the shell is first loaded in the folder that contains the .env file (e.g. opening a VSCode integrated terminal in a project root containing .env, or splitting a tmux pane in such a folder), I noticed the environment variables are not loaded.

This makes sense as the plugin is hooked onto `chpwd` which will only trigger when changing directories. Since the shell already starts at the target directory, there will be no calls at first.

I propose we also call `load-local-conf` initially to accomodate for these cases, thus sourcing the .env file on startup if it exists as well. 

Thank you once more in advance!