### PR TITLE
loading the .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ How to install
 
 ```
 cd ~/.oh-my-zsh/plugins
-git clone https://github.com/johnhamelink/env-zsh.git env
+git clone https://github.com/ea-sam/env-zsh.git env
 vi ~/.zshrc && reload
 
 # edit your plugin list by adding 'env'

--- a/env.plugin.zsh
+++ b/env.plugin.zsh
@@ -4,7 +4,7 @@ autoload -U add-zsh-hook
 load-local-conf() {
      # check file exists, is regular file and is readable:
      if [[ -f .env && -r .env ]]; then
-       source .env
+       export $(grep -v '^#' .env | xargs)
      fi
 }
 


### PR DESCRIPTION
`source .env` no longer works for unknown reasons. I have modified loading of .env file to `export $(grep -v '^#' .env | xargs)` Please merge if it is satisfactory.