### PR TITLE
Additional `.env.term` optional file

### DIFF
--- a/env.plugin.zsh
+++ b/env.plugin.zsh
@@ -6,6 +6,10 @@ load-local-conf() {
      if [[ -f .env && -r .env ]]; then
        source .env
      fi
+     # additional env option to prevent conflicts between main Docker `.env` applications and terminal
+     if [[ -f .env.term && -r .env.term ]]; then
+       source .env.term
+     fi
 }
 
 load-local-conf


### PR DESCRIPTION
Through the `.env.term`, variables like PATH can be manage accordingly dynamically without entering in conflicts with other apps reading the main `.env` file like Docker.